### PR TITLE
Update parsing of DATABASE_URL in daemon.sh to ignore any URL parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .env
-fly.toml
 app

--- a/docker/daemon.sh
+++ b/docker/daemon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-_DB_REGEX='^postgres://\(.\+\):\(.\+\)@\(.\+\):\([0-9]\+\)/\(.\+\)$'
+_DB_REGEX='^postgres://\(.\+\):\(.\+\)@\(.\+\):\([0-9]\+\)/\(.\+\)\??.*$'
 
 TTRSS_DB_USER="$(echo "$DATABASE_URL" | sed -n "s|$_DB_REGEX|\1|p")"
 TTRSS_DB_PASS="$(echo "$DATABASE_URL" | sed -n "s|$_DB_REGEX|\2|p")"

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,37 @@
+app = "cyphus-ttrss"
+kill_signal = "SIGINT"
+kill_timeout = 30
+processes = []
+
+[env]
+  TTRSS_SELF_URL_PATH = "https://cyphus-ttrss.fly.dev/tt-rss"
+
+[mounts]
+  source = "data"
+  destination = "/var/www/html"
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 80
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "2m"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "5s"


### PR DESCRIPTION
Fly.io added `?sslmode=disable` to the end of my `DATABASE_URL`, which was then being interpreted as part of the database name, causing the deploy to fail.  This update will ignore anything after a `?`, thus preventing the parameters from polluting the database name.